### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,9 @@
 
 name: .NET Core Desktop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Byzan-Systems/002TN0014/security/code-scanning/1](https://github.com/Byzan-Systems/002TN0014/security/code-scanning/1)

To fix the issue, add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Based on the workflow's actions, it primarily interacts with the repository's contents (e.g., checking out code, running tests, and uploading artifacts). Therefore, the `contents: read` permission is sufficient. This block should be added at the root level of the workflow file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
